### PR TITLE
Define objects

### DIFF
--- a/lib/selfie.ex
+++ b/lib/selfie.ex
@@ -66,4 +66,16 @@ defmodule Selfie do
   defp handle_undefined(struct, name, [], _), do: Map.fetch!(struct, name)
 
   defp handle_undefined(_, _, _, error), do: raise(error)
+
+  defmacro defobject(params) do
+    quote do
+      defstruct unquote(params ++ [self: nil])
+
+      def new(params \\ %{}) do
+        struct = struct(__MODULE__, params)
+
+        Map.put(struct, :self, &(Selfie.self_apply(struct, &1, &2)))
+      end
+    end
+  end
 end

--- a/test/selfie_test.exs
+++ b/test/selfie_test.exs
@@ -3,7 +3,7 @@ defmodule SelfieTest do
   import Selfie
 
   defmodule Pair do
-    defstruct x: 3, y: 4
+    defobject x: 3, y: 4
 
     def sum(%Pair{x: x, y: y}), do: x + y
 
@@ -28,5 +28,9 @@ defmodule SelfieTest do
     assert_raise FunctionClauseError, fn ->
       %Pair{x: 1, y: 1} |> self_apply(:foo, :bar)
     end
+  end
+
+  test "adds a new function that gives access to Selfie.self_apply/2" do
+    assert Pair.new().self.(:sum, [])
   end
 end


### PR DESCRIPTION
Add `self` to structs for easy access to module functions for that struct